### PR TITLE
Reset stubbing

### DIFF
--- a/include/mockitopp/detail/stubbing/dynamic_object.hpp
+++ b/include/mockitopp/detail/stubbing/dynamic_object.hpp
@@ -130,6 +130,17 @@ namespace mockitopp
             return *reinterpret_cast<dynamic_vfunction<typename remove_member_function_pointer_cv<M>::type>*>(vtable_mocks[offset]);
          }
 
+         template <typename M>
+         void delete_function(M ptr2member)
+         {
+            int offset = vtable_offset_helper::get(ptr2member);
+            if (vtable_mocks[offset] != 0) {
+               delete reinterpret_cast<dynamic_vfunction_base*>(vtable_mocks[offset]);
+               vtable_actual_ptr->functions[offset] = horrible_cast<void*>(&dynamic_object::missing_vfunction);
+               vtable_mocks[offset] = 0;
+            }
+         }
+
          void missing_vfunction()
             { throw missing_implementation_exception(); }
       };

--- a/include/mockitopp/detail/stubbing/dynamic_vfunction.hpp
+++ b/include/mockitopp/detail/stubbing/dynamic_vfunction.hpp
@@ -86,6 +86,12 @@ namespace mockitopp
             stubbing_progress->push_back(action_type(new throwable_action<R, T>(throwable)));
             return *this;
          }
+
+         dynamic_vfunction_progress& reset()
+         {
+            stubbing_progress->clear();
+            return *this;
+         }
       };
 
       template <>
@@ -106,6 +112,12 @@ namespace mockitopp
          dynamic_vfunction_progress& thenThrow(T throwable)
          {
             stubbing_progress->push_back(action_type(new throwable_action<void, T>(throwable)));
+            return *this;
+         }
+
+         dynamic_vfunction_progress& reset()
+         {
+            stubbing_progress->clear();
             return *this;
          }
       };
@@ -232,6 +244,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -327,6 +342,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -422,6 +440,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -517,6 +538,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -612,6 +636,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -707,6 +734,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -802,6 +832,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -897,6 +930,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -992,6 +1028,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -1087,6 +1126,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }
@@ -1182,6 +1224,9 @@ namespace mockitopp
                    { throw partial_implementation_exception(); }
                actions = &(fuzzy_match->val);
             }
+            if (actions->empty())
+               { throw partial_implementation_exception(); }
+
             action_type action = actions->front();
             if(actions->size() > 1)
                { actions->pop_front(); }

--- a/include/mockitopp/mock_object.hpp
+++ b/include/mockitopp/mock_object.hpp
@@ -39,6 +39,10 @@ namespace mockitopp
       template <typename M>
       detail::dynamic_vfunction<typename detail::remove_member_function_pointer_cv<M>::type>& operator() (M ptr2member)
          { return expect(ptr2member); }
+
+      template <typename M>
+      void reset(M ptr2member)
+         { delete_function(ptr2member); }
    };
 } // namespace mockitopp
 

--- a/test/SConscript
+++ b/test/SConscript
@@ -40,6 +40,7 @@ TEST_SRC = [
    'src/test_mfp_cv.cpp',
    'src/test_multiple_inheritance.cpp',
    'src/test_overloaded_functions.cpp',
+   'src/test_resetting_stubs.cpp',
    'src/test_verify.cpp',
    'src/bugs/issue_7.cpp',
    'src/bugs/issue_8.cpp',

--- a/test/src/test_resetting_stubs.cpp
+++ b/test/src/test_resetting_stubs.cpp
@@ -1,0 +1,107 @@
+#include "tpunit++.hpp"
+#include <mockitopp/mockitopp.hpp>
+
+struct test_resetting_stubs : tpunit::TestFixture
+{
+   test_resetting_stubs() : tpunit::TestFixture
+   (
+      TEST(test_resetting_stubs::reset_with_stubs),
+      TEST(test_resetting_stubs::reset_with_no_stubs),
+      TEST(test_resetting_stubs::add_stub_after_reset)
+   )
+   {}
+
+   struct interface
+   {
+      virtual int foo() = 0;
+   };
+
+   void reset_with_stubs()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when().thenReturn(0)
+                                   .thenReturn(1)
+                                   .thenReturn(2);
+      mock.reset(&interface::foo);
+      ASSERT_THROW(mock.getInstance().foo(), mockitopp::missing_implementation_exception);
+   }
+
+   void reset_with_no_stubs()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock.reset(&interface::foo);
+      ASSERT_THROW(mock.getInstance().foo(), mockitopp::missing_implementation_exception);
+   }
+
+   void add_stub_after_reset()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when().thenReturn(0);
+      mock.reset(&interface::foo);
+      mock(&interface::foo).when().thenReturn(1);
+      ASSERT_EQUAL(1, mock.getInstance().foo());
+   }
+
+} __test_resetting_stubs;
+
+struct test_resetting_stubs_with_args : tpunit::TestFixture
+{
+   test_resetting_stubs_with_args() : tpunit::TestFixture
+   (
+      TEST(test_resetting_stubs_with_args::reset_with_stubs),
+      TEST(test_resetting_stubs_with_args::reset_with_no_stubs),
+      TEST(test_resetting_stubs_with_args::add_stub_after_reset),
+      TEST(test_resetting_stubs_with_args::add_stub_after_reset_iteratively)
+   )
+   {}
+
+   struct interface
+   {
+      virtual int foo(int) = 0;
+   };
+
+   void reset_with_stubs()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when(0).thenReturn(0)
+                                   .thenReturn(1)
+                                   .thenReturn(2);
+      mock(&interface::foo).when(0).reset();
+      ASSERT_THROW(mock.getInstance().foo(0), mockitopp::partial_implementation_exception);
+   }
+
+   void reset_with_other_arg_stubs()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when(0).thenReturn(0);
+      mock(&interface::foo).when(1).thenReturn(1);
+      mock(&interface::foo).when(0).reset();
+      ASSERT_EQUAL(1, mock.getInstance().foo(1));
+   }
+
+   void reset_with_no_stubs()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when(0).reset();
+      ASSERT_THROW(mock.getInstance().foo(0), mockitopp::partial_implementation_exception);
+   }
+
+   void add_stub_after_reset()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when(0).thenReturn(0);
+      mock(&interface::foo).when(0).reset();
+      mock(&interface::foo).when(0).thenReturn(1);
+      ASSERT_EQUAL(1, mock.getInstance().foo(0));
+   }
+
+   void add_stub_after_reset_iteratively()
+   {
+      mockitopp::mock_object<interface> mock;
+      mock(&interface::foo).when(0).thenReturn(0)
+                                   .reset()
+                                   .thenReturn(1);
+      ASSERT_EQUAL(1, mock.getInstance().foo(0));
+   }
+
+} __test_resetting_stubs_with_args;


### PR DESCRIPTION
As described in issue #15, no function was providing a way to reset the stubbing behaviour.
I've just apply the patch proposed by the user. At first look, it seem fine and come with some tests.
The pull request will trigger a run of all tests on it. 
